### PR TITLE
deluge.lua - display pads with max brightness

### DIFF
--- a/lib/devices/deluge.lua
+++ b/lib/devices/deluge.lua
@@ -7,7 +7,7 @@ deluge.width = 16
 deluge.height = 8
 
 -- mapping velocity (0-127) to LED brightness on deluge side, brightness map needs 16 values
-deluge.brightness_map = {0,15,23,31,39,47,55,63,71,79,87,95,103,111,119,127}
+deluge.brightness_map = {0,15,23,31,39,47,55,63,71,79,87,95,103,111,119,126}
 
 -- 0 is bottom left of deluge main grid, 127 is top right of deluge main grid
 -- 0 is C-2, 127 is G8


### PR DESCRIPTION
Pad that are supposed to be displayed with maximum brightness were displayed with zero brightness, completely dark (at least in Dreamsequence script). This led to pad for selected chord not be displayed in the play area. This micro edit fixes this issue. Now pads are shown with highest brightness.